### PR TITLE
feat: Added public function to check if there are unsaved changes

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -357,6 +357,29 @@ function getTimestampString(date: Date = new Date()): string {
     return `${year}${month}${day}_${hour}${minute}${second}`
 }
 
+function hashArrayOfObjects<T extends Record<string, any>>(arr: T[]): number {
+    const jsonString = JSON.stringify(arr, (key, value) => {
+        if (value && typeof value === 'object' && !Array.isArray(value)) {
+            return Object.keys(value).sort().reduce((sortedObject: Record<string, any>, k) => {
+                sortedObject[k] = value[k]
+                return sortedObject
+            }, {});
+        }
+        return value
+    });
+
+    let hash = 0
+    if (jsonString.length === 0) {
+        return hash
+    }
+    for (let i = 0; i < jsonString.length; i++) {
+        const char = jsonString.charCodeAt(i)
+        hash = ((hash << 5) - hash) + char
+        hash |= 0
+    }
+    return hash
+}
+
 export {
     base64ToImageBitmap,
     formatFileSize,
@@ -377,5 +400,6 @@ export {
     once,
     convertKonvaRectToPdfRect,
     stringToPDFHexString,
-    getTimestampString
+    getTimestampString,
+    hashArrayOfObjects
 }


### PR DESCRIPTION
I wanted to use a window beforeunload event listener to warn the user before leaving the site with unsaved changes.
To be able to do this i needed a public instance of the extension with a method to check for unsaved changes.
I'm using a simple hash/checksum calculation of the initial annotation list and compare that with the current one.
Its working for me, but as i'm not familiar with react, maybe there is a better way to achive that.

With those changes i can do this:

![grafik](https://github.com/user-attachments/assets/0fab36a6-1dbb-46eb-b866-f8a926959b98)
